### PR TITLE
    fix: prevent racing of requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "new tag $NEW_TAG"
 
       - name: Set release text
-        run: git show `git log -2 | grep commit |tail -1 | awk -F' ' '{print $2}'` >> release.txt
+        run: git show -s --format=%B `git log -2 | grep commit |tail -1 | awk -F' ' '{print $2}'` >> release.txt
 
 
       - name: Create release


### PR DESCRIPTION
    Introduce a request id and a reference to latest request. Dismiss
    incoming responses other than from latest request.

    Remove timeouts which were used to mitigate the racing issue but are
    obsolete now.