### PR TITLE
feat: allow provided config object to extend other configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mesa",
-  "version": "1.0.57",
+  "version": "1.0.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mesa",
-      "version": "1.0.57",
+      "version": "1.0.56",
       "license": "ISC",
       "bin": {
         "mesa": "bin/init.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mesa325",
-  "version": "1.0.57",
+  "version": "1.0.56",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
BREAKING CHANGE: `extends` key in config file is now used for extending other config files
