### PR TITLE
feat: stop concurrent actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+concurrency:
+  groups: tag-and-release
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-COMMIT.md
+commit

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,34 @@
 NPM_TOKEN=$(shell awk -F'=' '{print $$2}' ~/.npmrc)
-COMMIT_FILE = COMMIT.md
+COMMIT_FILE = commit
+
 generate:
 	./bin/init.js
-commit:
-	code COMMIT.md
 npm:
 	@echo $(NPM_TOKEN) > npm
 	gh secret set NPM_TOKEN < npm
 	rm npm
+patch:
+	echo fix: title > $(COMMIT_FILE)
+	code $(COMMIT_FILE)
+minor:
+	echo feat: title > $(COMMIT_FILE)
+	code $(COMMIT_FILE)
+major:
+	echo BREAKING_CHANGE: title > $(COMMIT_FILE)
+	code $(COMMIT_FILE)
 
 ifneq ("$(wildcard $(COMMIT_FILE))","")
 pr:
 	git rebase origin/main
 	git reset origin/main
 	git add .
-	git commit -F COMMIT.md
+	git commit -F $(COMMIT_FILE)
 	git push -f
 	gh pr create --fill
-	rm COMMIT.md
+	rm $(COMMIT_FILE)
 else
 pr:
-	@echo run \"make commit\" to create conventional commits before creating PR
+	@echo run \"make patch\" , \"make minor\", or \"make major\" to create conventional commits before creating PR
 endif
 
 gh:


### PR DESCRIPTION
prevents two PR's trying to bump the version number at same time
