### PR TITLE
feat: prevent concurrency for version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 concurrency:
-  groups: tag-and-release
+  group: tag-and-release
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
prevent github action from allowing multiple actions trying to bump version number at same time
